### PR TITLE
import: Use ObjectId from bson instead of pymongo

### DIFF
--- a/scalymongo/__init__.py
+++ b/scalymongo/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from pymongo.objectid import ObjectId
+from bson.objectid import ObjectId
 
 from scalymongo.document import Document
 from scalymongo.connection import Connection


### PR DESCRIPTION
pymongo >= 2.2 stops importing ObjectId from bson
so it need to be pulled in directly.

proposed fix for #8
