### PR TITLE
Replace Connection with MongoClient

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'ScalyMongo'
 copyright = u'2011, Allan Caffee'
-version = '0.1.8'
+version = '0.2.0'
 release = version
 
 exclude_patterns = []

--- a/scalymongo/connection.py
+++ b/scalymongo/connection.py
@@ -5,15 +5,15 @@ Connection
 """
 import warnings
 
-import pymongo
+from pymongo import MongoClient
 
 from scalymongo.document import get_concrete_classes
 
 
-class Connection(pymongo.Connection):
+class Connection(MongoClient):
     """A connection to a MongoDB database.
 
-    This is a wrapper for a :class:`pymongo.connection.Connection`.
+    This is a wrapper for a :class:`pymongo.mongo_client.MongoClient`.
 
     """
 

--- a/scalymongo/document.py
+++ b/scalymongo/document.py
@@ -215,7 +215,7 @@ class Document(SchemaDocument):
         return Cursor(result, cls)
 
     @classmethod
-    def find_and_modify(cls, query={}, update=None,
+    def find_and_modify(cls, query=ClassDefault, update=None,
                         allow_global=False, **kwargs):
         """Find and atomically update a single document.
 
@@ -241,6 +241,9 @@ class Document(SchemaDocument):
         .. _findAndModify: http://www.mongodb.org/display/DOCS/findAndModify+Command
 
         """
+        if query is ClassDefault:
+            query = {}
+
         if not allow_global:
             cls.check_query_sharding(query)
 

--- a/scalymongo/document.py
+++ b/scalymongo/document.py
@@ -7,8 +7,6 @@ The base document models.
 """
 from warnings import warn
 
-import functools
-
 from pymongo.errors import OperationFailure
 
 from scalymongo.cursor import Cursor

--- a/scalymongo/document.py
+++ b/scalymongo/document.py
@@ -100,16 +100,11 @@ class Document(SchemaDocument):
         if self.write_concern_override is not None:
             self.collection.write_concern = self.write_concern_override
 
-    def save(self, safe=ClassDefault, **kwargs):
+    def save(self, **kwargs):
         """Save this document.
 
         If this document has already been saved an :class:`UnsafeBehaviorError`
         will be raised.  The document will be validated before saving.
-
-        :keyword safe: Corresponds to the `safe` keyword of the underlying
-            function.  If not specified this defaults to using the
-            :data:`safe_insert` attribute.  (Which in turn is set to ``True``
-            on the :class:`Document`.
 
         All additional keyword arguments will be passed to
         :meth:`pymongo.collection.Collection.save`.
@@ -121,7 +116,7 @@ class Document(SchemaDocument):
                 ' Further alterations should use modify.')
 
         self.validate()
-        self.collection.save(self, safe=safe, **kwargs)
+        self.collection.save(self, **kwargs)
 
     def reload(self):
         """Reload this document.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name='scalymongo',
-    version='0.1.8',
+    version='0.2.0',
     description='A scaling-centric MongoDB object document mapper',
     keywords = 'mongo sharding db',
     url='https://github.com/allancaffee/scaly-mongo',
@@ -18,7 +18,7 @@ setup(
     author_email='allan.caffee@gmail.com',
     license='BSD',
     packages=['scalymongo', 'scalymongo.manage'],
-    install_requires=['pymongo>=1.9'],
+    install_requires=['pymongo>=2.4'],
     test_suite='tests',
     long_description=read('README.rst'),
     entry_points={

--- a/tests/acceptance/test_save.py
+++ b/tests/acceptance/test_save.py
@@ -13,6 +13,7 @@ class User(Document):
 
     __database__ = 'test'
     __collection__ = 'users'
+    write_concern_override = {'w': 0}
 
 
 class BaseSaveTest(BaseAcceptanceTest):
@@ -23,6 +24,9 @@ class BaseSaveTest(BaseAcceptanceTest):
         cls.doc = cls.connection.models.User()
         cls.doc['name'] = 'Alice'
         cls.doc['age'] = 32
+
+    def should_have_non_default_write_concern(self):
+        assert self.doc.collection.write_concern == {'w': 0}
 
 
 class TestSave(BaseSaveTest):
@@ -40,7 +44,7 @@ class TestSave(BaseSaveTest):
 
 
 class TestDoubleSave(BaseSaveTest):
-    
+
     @classmethod
     def setup_class(cls):
         BaseSaveTest.setup_class()

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -8,7 +8,7 @@ import scalymongo.connection as mod
 class DescribeConnectionClass(object):
 
     def should_extend_pymongo_connection(self):
-        assert issubclass(Connection, mod.pymongo.Connection)
+        assert issubclass(Connection, mod.MongoClient)
 
 
 class BaseConnectionTest(DingusTestCase(Connection)):

--- a/tests/unit/test_document.py
+++ b/tests/unit/test_document.py
@@ -237,8 +237,8 @@ class WhenDocumentHasNoId(
 
         self.doc.save()
 
-    def should_save_document_into_collection_with_safe_true(self):
-        assert self.doc.collection.calls('save', self.doc, safe=True)
+    def should_save_document_into_collection(self):
+        assert self.doc.collection.calls('save', self.doc)
 
 
 class WhenDocumentHasNoIdAndKeywordsAreSpecified(
@@ -248,7 +248,7 @@ class WhenDocumentHasNoIdAndKeywordsAreSpecified(
 
     def setup(self):
         BaseSaveTest.setup(self)
-        self.kwargs = {'foo': 1, 'bar': 2, 'safe': False}
+        self.kwargs = {'foo': 1, 'bar': 2, 'w': 0}
 
         self.doc.save(**self.kwargs)
 
@@ -943,7 +943,7 @@ class TestRemoveWithAllowGlobalFalseAndKWArgs(
 
     def setup(self):
         BaseRemove.setup(self)
-        self.kwargs = dict(safe=True, w=3, j=True)
+        self.kwargs = dict(w=3, j=True)
         self.returned = self.MyDoc.remove(
             self.spec, allow_global=True, **self.kwargs)
 
@@ -956,7 +956,7 @@ class TestRemoveWithAllowGlobalTrueAndKWArgs(
 
     def setup(self):
         BaseRemove.setup(self)
-        self.kwargs = dict(safe=True, w=3, j=True)
+        self.kwargs = dict(w=3, j=True)
         self.returned = self.MyDoc.remove(
             self.spec, allow_global=True, **self.kwargs)
 


### PR DESCRIPTION
Old and busted; meet new hotness http://emptysquare.net/blog/pymongos-new-default-safe-writes/
`MongoClient` is new and shiny. As far as functionality goes, the API is backwards compatible with the old `Connection` class so this change shouldn't break anyone's code. The major change is that writes are safe by default. If you want to use unsafe writes, set `w=0`. If you use the `safe` kwarg in your code, you'll get warnings since it has been deprecated in favor of the `w` option. I've also replaced the existing `safe_insert` attribute with a new `write_concern_override` attribute. Unlike `safe_insert`, `write_concern_override` will impact all writes, not just calls to the save method. Usage of `safe_insert` will print a `DeprecationWarning`.
